### PR TITLE
E2E тест auth #182

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,15 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "npm run db:clean && jest --config ./test/jest-e2e.json",
+    "test:e2e": "npm run seed:test && jest --config ./test/jest-e2e.json",
     "seed:admin": "ts-node -r tsconfig-paths/register src/seeding/admin.seed.ts",
     "seed:test:users": "ts-node -r tsconfig-paths/register src/seeding/seed-test-users.ts",
     "seed:categories": "ts-node -r tsconfig-paths/register src/seeding/categories.seed.ts",
     "seed:cities": "ts-node -r tsconfig-paths/register src/seeding/cities.seed.ts",
-    "db:clean": "ts-node -r tsconfig-paths/register src/seeding/clean-db.ts"
+    "seed:test:skills": "ts-node -r tsconfig-paths/register src/seeding/seed-test-skills.ts",
+    "seed:users": "ts-node -r tsconfig-paths/register src/seeding/seed-test-users.ts",
+    "db:clean": "ts-node -r tsconfig-paths/register src/seeding/clean-db.ts",
+    "seed:test": "npm run db:clean && npm run seed:admin && npm run seed:categories && npm run seed:cities && npm run seed:test:users && npm run seed:test:skills"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:e2e": "npm run db:clean && jest --config ./test/jest-e2e.json",
     "seed:admin": "ts-node -r tsconfig-paths/register src/seeding/admin.seed.ts",
     "seed:test:users": "ts-node -r tsconfig-paths/register src/seeding/seed-test-users.ts",
     "seed:categories": "ts-node -r tsconfig-paths/register src/seeding/categories.seed.ts",
-    "seed:cities": "ts-node -r tsconfig-paths/register src/seeding/cities.seed.ts"
+    "seed:cities": "ts-node -r tsconfig-paths/register src/seeding/cities.seed.ts",
+    "db:clean": "ts-node -r tsconfig-paths/register src/seeding/clean-db.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,7 +1,6 @@
 import { Controller, Post, Body, UseGuards, Req, Res } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { RegisterDTO } from './dto/register.dto';
-import { RefreshTokenGuard } from './guards/refreshToken.guard';
 import { TRequestWithRefreshToken } from './auth.types';
 import { LoginDTO } from './dto/login.dto';
 import { Response } from 'express';
@@ -13,6 +12,7 @@ import {
   ApiAuthRefresh,
   ApiAuthRegister,
 } from './auth.swagger';
+import { JwtRefreshGuard } from './guards/jwt-refresh.guard';
 
 @Controller('auth')
 export class AuthController {
@@ -30,7 +30,7 @@ export class AuthController {
   }
 
   @ApiAuthRefresh()
-  @UseGuards(RefreshTokenGuard)
+  @UseGuards(JwtRefreshGuard)
   @Post('refresh')
   async refresh(
     @Req() req: TRequestWithRefreshToken,

--- a/src/auth/guards/refreshToken.guard.ts
+++ b/src/auth/guards/refreshToken.guard.ts
@@ -1,5 +1,0 @@
-import { Injectable } from '@nestjs/common';
-import { AuthGuard } from '@nestjs/passport';
-
-@Injectable()
-export class RefreshTokenGuard extends AuthGuard('jwt-refresh') {}

--- a/src/seeding/admin.seed.ts
+++ b/src/seeding/admin.seed.ts
@@ -6,10 +6,12 @@ import { Skill } from '../skills/entities/skill.entity';
 import { Category } from '../categories/entities/category.entity';
 import { UserRole } from '../users/enums/users.enums';
 import { databaseConfig } from '../config/database.config';
+import { Request } from '../requests/entities/request.entity';
+import { City } from 'src/cities/entities/city.entity';
 
 const AppDataSource = new DataSource({
   ...databaseConfig(),
-  entities: [User, Skill, Category],
+  entities: [User, Skill, Category, Request, City],
 });
 
 async function seedAdmin() {

--- a/src/seeding/categories.seed.ts
+++ b/src/seeding/categories.seed.ts
@@ -2,6 +2,10 @@ import 'dotenv/config';
 import { DataSource } from 'typeorm';
 import { Category } from '../categories/entities/category.entity';
 import { databaseConfig } from '../config/database.config';
+import { User } from 'src/users/entities/user.entity';
+import { City } from 'src/cities/entities/city.entity';
+import { Skill } from 'src/skills/entities/skill.entity';
+import { Request } from 'src/requests/entities/request.entity';
 
 interface SeedCreateCategory {
   name: string;
@@ -12,7 +16,7 @@ export const CategoriesData: SeedCreateCategory[] = [ { name: 'Творчест�
 
 const AppDataSource = new DataSource({
   ...databaseConfig(),
-  entities: [Category],
+  entities: [Category, User, City, Skill, Request],
 });
 
 async function seedCategories() {

--- a/src/seeding/clean-db.ts
+++ b/src/seeding/clean-db.ts
@@ -1,0 +1,27 @@
+import { dataSource } from 'src/config/database.config';
+
+const tables = ['users', 'categories', 'cities', 'skills'];
+
+async function cleanDb() {
+  try {
+    await dataSource.initialize();
+    console.log('Очистка базы данных...');
+
+    // удалить все записи + сбросить id sequence
+    await dataSource.query(`
+      TRUNCATE TABLE ${tables.join(', ')}
+      RESTART IDENTITY
+      CASCADE;
+    `);
+
+    console.log('База данных очищена');
+  } finally {
+    if (dataSource.isInitialized) {
+      await dataSource.destroy();
+    }
+  }
+}
+
+cleanDb().catch((error) => {
+  console.error('Ошибка при очистке базы данных:', error);
+});

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -12,6 +12,11 @@ import { Reflector } from '@nestjs/core';
 import cookieParser from 'cookie-parser';
 import { AllExceptionsFilter } from 'src/common/all-exception.filter';
 import { RegisterDTO } from 'src/auth/dto/register.dto';
+import { Repository } from 'typeorm';
+import { User } from 'src/users/entities/user.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+let userRepository: Repository<User>
 
 describe('AuthController (e2e)', () => {
   let app: INestApplication;
@@ -31,6 +36,8 @@ describe('AuthController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+
+    userRepository = moduleFixture.get<Repository<User>>(getRepositoryToken(User))
 
     app.use(cookieParser());
     app.useGlobalInterceptors(
@@ -62,6 +69,7 @@ describe('AuthController (e2e)', () => {
     await app.init();
   });
 
+  // ===== Registration =====
   it('/auth/register (POST) => should register a new user', async () => {
     const res = await request(app.getHttpServer())
       .post('/auth/register')
@@ -82,6 +90,7 @@ describe('AuthController (e2e)', () => {
       .expect(409);
   });
 
+  // ===== Login =====
   it('/auth/login (POST) => should login a user', async () => {
     const res = await request(app.getHttpServer())
       .post('/auth/login')
@@ -95,7 +104,7 @@ describe('AuthController (e2e)', () => {
     expect(res.headers['set-cookie']).toBeDefined();
 
     accessToken = res.body.accessToken;
-    refreshToken = res.headers['set-cookie'][0]
+    refreshToken = res.body.refreshToken || res.headers['set-cookie'][0];
   });
 
   it('/auth/login (POST) => should fail with wrong password', async () => {
@@ -108,27 +117,34 @@ describe('AuthController (e2e)', () => {
       .expect(401);
   });
 
+  // ===== Refresh =====
   it('/auth/refresh (POST) => should refresh tokens', async () => {
+    console.log('====== Refresh token cookie ======:', refreshToken);
 
     const res = await request(app.getHttpServer())
       .post('/auth/refresh')
-      .set('Cookie', refreshToken.split(';')[0])
+      .send({
+        refreshToken,
+      })
       .expect(201);
 
     expect(res.body).toHaveProperty('accessToken');
     // expect(res.headers['set-cookie']).toBeDefined();
 
     accessToken = res.body.accessToken;
-    refreshToken = res.headers['set-cookie'][0]
+    refreshToken = res.body.refreshToken || res.headers['set-cookie'][0];
   });
 
   it('/auth/refresh (POST) => should fail with invalid refresh token', async () => {
     await request(app.getHttpServer())
       .post('/auth/refresh')
-      .set('Cookie', 'refreshToken=invalidtoken')
+      .send({
+        refreshToken: 'invalidtoken',
+      })
       .expect(401);
   });
 
+  // ===== Logout =====
   it('/auth/logout (POST) => should logout a user', async () => {
     const res = await request(app.getHttpServer())
       .post('/auth/logout')
@@ -136,6 +152,14 @@ describe('AuthController (e2e)', () => {
       .expect(201);
 
     expect(res.body).toEqual({ message: 'Успешный выход' });
+
+    const testUser = await userRepository.findOne({
+      where: {
+        email: registerUserDto.email,
+      },
+    });
+
+    expect(testUser?.refreshToken).toBeNull();
   });
 
   it('/auth/logout (POST) => should fail with invalid access token', async () => {

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,0 +1,147 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ClassSerializerInterceptor,
+  INestApplication,
+  ValidationPipe,
+} from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from './../src/app.module';
+import { describe, beforeEach, it } from '@jest/globals';
+import { Reflector } from '@nestjs/core';
+import cookieParser from 'cookie-parser';
+import { AllExceptionsFilter } from 'src/common/all-exception.filter';
+import { RegisterDTO } from 'src/auth/dto/register.dto';
+
+describe('AuthController (e2e)', () => {
+  let app: INestApplication;
+
+  const registerUserDto: RegisterDTO = {
+    name: 'test_user',
+    email: 'test@example.com',
+    password: 'Password123!',
+  };
+
+  let accessToken: string;
+  let refreshToken: string;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+
+    app.use(cookieParser());
+    app.useGlobalInterceptors(
+      new ClassSerializerInterceptor(app.get(Reflector)),
+    );
+    app.useGlobalFilters(new AllExceptionsFilter());
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+        transformOptions: {
+          enableImplicitConversion: true,
+        },
+        forbidUnknownValues: true,
+
+        exceptionFactory: (errors) => {
+          return new BadRequestException({
+            message: 'Validation failed',
+            errors: errors.map((err) => ({
+              field: err.property,
+              errors: Object.values(err.constraints || {}),
+            })),
+          });
+        },
+      }),
+    );
+
+    await app.init();
+  });
+
+  it('/auth/register (POST) => should register a new user', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send(registerUserDto)
+      .expect(201);
+
+    expect(res.body).toHaveProperty('accessToken');
+    expect(res.headers['set-cookie']).toBeDefined();
+
+    accessToken = res.body.accessToken;
+    refreshToken = res.headers['set-cookie'][0]
+  });
+
+  it('/auth/register (POST) => should fail duplicate email', async () => {
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send(registerUserDto)
+      .expect(409);
+  });
+
+  it('/auth/login (POST) => should login a user', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        email: registerUserDto.email,
+        password: registerUserDto.password,
+      })
+      .expect(201);
+
+    expect(res.body).toHaveProperty('accessToken');
+    expect(res.headers['set-cookie']).toBeDefined();
+
+    accessToken = res.body.accessToken;
+    refreshToken = res.headers['set-cookie'][0]
+  });
+
+  it('/auth/login (POST) => should fail with wrong password', async () => {
+    await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        email: registerUserDto.email,
+        password: 'WrongPassword!',
+      })
+      .expect(401);
+  });
+
+  it('/auth/refresh (POST) => should refresh tokens', async () => {
+
+    const res = await request(app.getHttpServer())
+      .post('/auth/refresh')
+      .set('Cookie', refreshToken.split(';')[0])
+      .expect(201);
+
+    expect(res.body).toHaveProperty('accessToken');
+    // expect(res.headers['set-cookie']).toBeDefined();
+
+    accessToken = res.body.accessToken;
+    refreshToken = res.headers['set-cookie'][0]
+  });
+
+  it('/auth/refresh (POST) => should fail with invalid refresh token', async () => {
+    await request(app.getHttpServer())
+      .post('/auth/refresh')
+      .set('Cookie', 'refreshToken=invalidtoken')
+      .expect(401);
+  });
+
+  it('/auth/logout (POST) => should logout a user', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/auth/logout')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(201);
+
+    expect(res.body).toEqual({ message: 'Успешный выход' });
+  });
+
+  it('/auth/logout (POST) => should fail with invalid access token', async () => {
+    await request(app.getHttpServer())
+      .post('/auth/logout')
+      .set('Authorization', 'Bearer invalidtoken')
+      .expect(401);
+  });
+});


### PR DESCRIPTION
https://github.com/Pr-month/SkillSwap_41_2/issues/182

- добавлена очистка базы данных, настроен сидинг для корректной работы e2e тестов модуля auth
- поправлены сидинги `admin.seed.ts` и `categories.seed.ts` (дополнены entities)
- удалена дублируйщая логику `jwt-refresh` гарда `refreshToken.guards.ts`
- добален e2e тест модуля auth