### PR TITLE
refactor: rename get-skills DTO and fix validation message

### DIFF
--- a/src/skills/dto/get-skills.dto.ts
+++ b/src/skills/dto/get-skills.dto.ts
@@ -22,7 +22,7 @@ export class GetSkillsQueryDto {
   @Type(() => Number)
   @IsInt({ message: 'limit должен быть целым числом' })
   @Min(1, { message: 'limit должен быть больше 0' })
-  @Max(21, { message: 'limit не должен превышать 24' })
+  @Max(21, { message: 'limit не должен превышать 21' })
   limit?: number;
 
   @IsOptional()

--- a/src/skills/skills.controller.ts
+++ b/src/skills/skills.controller.ts
@@ -13,7 +13,7 @@ import {
 import { TRequestWithUser } from 'src/auth/auth.types';
 import { JwtAccessGuard } from '../auth/guards/jwt-access.guard';
 import { CreateSkillDto } from './dto/create-skill.dto';
-import { GetSkillsQueryDto } from './dto/get-skills';
+import { GetSkillsQueryDto } from './dto/get-skills.dto';
 import { UpdateSkillDto } from './dto/update-skill.dto';
 import { SkillsService } from './skills.service';
 import {

--- a/src/skills/skills.service.spec.ts
+++ b/src/skills/skills.service.spec.ts
@@ -7,7 +7,7 @@ import { Repository } from 'typeorm';
 import { Category } from '../categories/entities/category.entity';
 import { User } from '../users/entities/user.entity';
 import { CreateSkillDto } from './dto/create-skill.dto';
-import { GetSkillsQueryDto } from './dto/get-skills';
+import { GetSkillsQueryDto } from './dto/get-skills.dto';
 import { UpdateSkillDto } from './dto/update-skill.dto';
 import { Skill } from './entities/skill.entity';
 import { SkillsService } from './skills.service';

--- a/src/skills/skills.service.ts
+++ b/src/skills/skills.service.ts
@@ -12,7 +12,7 @@ import { Repository } from 'typeorm';
 import { Category } from '../categories/entities/category.entity';
 import { User } from '../users/entities/user.entity';
 import { CreateSkillDto } from './dto/create-skill.dto';
-import { GetSkillsQueryDto } from './dto/get-skills';
+import { GetSkillsQueryDto } from './dto/get-skills.dto';
 import { UpdateSkillDto } from './dto/update-skill.dto';
 import { Skill } from './entities/skill.entity';
 


### PR DESCRIPTION
- Rename src/skills/dto/get-skills.ts to get-skills.dto.ts to follow project naming conventions.
- Update import references in SkillsController and SkillsService.
- Fix a typo in the Max validation decorator error message for the limit field.