### PR TITLE
feat: implement dynamic cities fetching and storage

### DIFF
--- a/frontend/src/api/skillSwapApi.ts
+++ b/frontend/src/api/skillSwapApi.ts
@@ -2,6 +2,7 @@ import { getCookie } from '@/shared/utils/cookies';
 import { api } from './apiClient';
 import { TAuthResponse, TLoginData } from './types/auth';
 import { TCategoriesResponse } from './types/categories';
+import { TCitiesResponse } from './types/cities';
 import { TSkillResponse } from './types/skill';
 import { TUpdateProfileData, TUpdateProfileResponse, TUsersResponse } from './types/users';
 
@@ -17,6 +18,12 @@ export const getCategoriesApi = async () => {
  */
 export const getSkillsApi = async () => {
   return api.get<TSkillResponse>('/api/skills');
+};
+/**
+ * Получение списка городов
+ */
+export const getCitiesApi = async () => {
+  return api.get<TCitiesResponse>('/api/cities');
 };
 
 /**

--- a/frontend/src/api/types/cities.ts
+++ b/frontend/src/api/types/cities.ts
@@ -1,0 +1,2 @@
+export type TCity = { id: number; name: string };
+export type TCitiesResponse = TCity[];

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,18 +1,19 @@
-import { MainLayout } from '@/widgets/Layout/MainLayout';
-import './styles/index.css';
-import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
-import { ComponentType, lazy, Suspense, useEffect } from 'react';
-import { ProtectedRoute } from '@/shared/ui/protectedRoute/protectedRoute';
-import { useDispatch } from '@/services/store/store';
-import { initializeLikes } from '@/services/slices/likeSlice';
-import { fetchCatalog } from '@/services/slices/catalogSlice';
-import { CatalogPage } from '@/pages/catalogPage/catalogPage';
-import { fetchUser } from '@/services/thunk/authUser';
 import { AboutPage } from '@/pages/AboutPage/AboutPage';
-import { fetchExchanges } from '@/services/slices/exchangeSlice';
-import { getSkills } from '@/services/slices/skillsSlice';
-import Loader from '@/shared/ui/Loader/loader';
+import { CatalogPage } from '@/pages/catalogPage/catalogPage';
+import { fetchCatalog } from '@/services/slices/catalogSlice';
 import { getCategories } from '@/services/slices/categorySlice';
+import { getCities } from '@/services/slices/citiesSlice';
+import { fetchExchanges } from '@/services/slices/exchangeSlice';
+import { initializeLikes } from '@/services/slices/likeSlice';
+import { getSkills } from '@/services/slices/skillsSlice';
+import { useDispatch } from '@/services/store/store';
+import { fetchUser } from '@/services/thunk/authUser';
+import Loader from '@/shared/ui/Loader/loader';
+import { ProtectedRoute } from '@/shared/ui/protectedRoute/protectedRoute';
+import { MainLayout } from '@/widgets/Layout/MainLayout';
+import { ComponentType, lazy, Suspense, useEffect } from 'react';
+import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import './styles/index.css';
 const ProfileDetailsPage = lazy(
   () =>
     new Promise<{ default: ComponentType<unknown> }>(resolve => {
@@ -41,7 +42,8 @@ function App() {
     dispatch(fetchCatalog());
     dispatch(fetchExchanges());
     dispatch(getSkills());
-    dispatch(getCategories())
+    dispatch(getCategories());
+    dispatch(getCities());
   }, [dispatch]);
 
   return (

--- a/frontend/src/pages/catalogPage/catalogPage.tsx
+++ b/frontend/src/pages/catalogPage/catalogPage.tsx
@@ -1,17 +1,20 @@
-import React from 'react';
-import { FiltersPanel } from '@/widgets/filters-panel/filtersPanel';
-import styles from './catalogPage.module.css';
-import { cities } from '@/shared/lib/cities';
-import SelectedFilters from '@/shared/ui/selectedFilters/selectedFilters';
-import Catalog from '@/widgets/catalog/catalog';
-import RequestPanel from '@/widgets/requestPanel/requestPanel';
-import { useSelector } from '@/services/store/store';
 import { userSliceSelectors } from '@/services/slices/authSlice';
 import { getCategoriesSelector } from '@/services/slices/categorySlice';
+import { getCitiesSelector } from '@/services/slices/citiesSlice';
+import { useSelector } from '@/services/store/store';
+import SelectedFilters from '@/shared/ui/selectedFilters/selectedFilters';
+import Catalog from '@/widgets/catalog/catalog';
+import { FiltersPanel } from '@/widgets/filters-panel/filtersPanel';
+import RequestPanel from '@/widgets/requestPanel/requestPanel';
+import React from 'react';
+import styles from './catalogPage.module.css';
 
 export const CatalogPage: React.FC = () => {
   // Получаем данные пользователя из Redux
   const user = useSelector(userSliceSelectors.selectUser);
+
+  const citiesFromStore = useSelector(getCitiesSelector);
+  const cityNames = citiesFromStore.map(c => c.name);
 
   const categories = useSelector(getCategoriesSelector);
 
@@ -25,7 +28,7 @@ export const CatalogPage: React.FC = () => {
   return (
     <div className={styles.filtersPage}>
       <div className={styles.filtersPanelPontainer}>
-        <FiltersPanel skillsCategories={mappingCategories} cities={cities} />
+        <FiltersPanel skillsCategories={mappingCategories} cities={cityNames} />
         {isAuthenticated && <RequestPanel />}
       </div>
 

--- a/frontend/src/pages/profileDetails/components/ProfileForm/ProfileForm.tsx
+++ b/frontend/src/pages/profileDetails/components/ProfileForm/ProfileForm.tsx
@@ -1,15 +1,15 @@
-import { useState, useRef, ChangeEvent } from 'react';
-import { PasswordChangeForm } from '../../components/PasswordChangeForm/PasswordChangeForm';
-import { useDispatch, useSelector } from '@/services/store/store';
-import { updateStepTwoData } from '@/services/slices/registrationSlice';
-import { userSliceSelectors, userSliceActions } from '@/services/slices/authSlice';
-import { Button } from '@/shared/ui/button/button';
-import { russianCities } from '@/shared/lib/cities';
 import { updateProfileApi } from '@/api/skillSwapApi';
-import * as yup from 'yup';
-import styles from './ProfileForm.module.css';
 import { useAuth } from '@/features/auth/context/AuthContext';
+import { userSliceActions, userSliceSelectors } from '@/services/slices/authSlice';
+import { getCitiesSelector } from '@/services/slices/citiesSlice';
+import { updateStepTwoData } from '@/services/slices/registrationSlice';
+import { useDispatch, useSelector } from '@/services/store/store';
+import { Button } from '@/shared/ui/button/button';
+import { ChangeEvent, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import * as yup from 'yup';
+import { PasswordChangeForm } from '../../components/PasswordChangeForm/PasswordChangeForm';
+import styles from './ProfileForm.module.css';
 
 type GenderType = 'Мужской' | 'Женский';
 
@@ -33,32 +33,6 @@ const formatDateForInput = (dateString?: string) => {
   }
 };
 
-const profileSchema = yup.object().shape({
-  name: yup
-    .string()
-    .required('Имя обязательно')
-    .min(2, 'Имя должно содержать минимум 2 символа')
-    .max(30, 'Имя должно содержать максимум 30 символов')
-    .matches(/^[а-яА-ЯёЁ\s-]+$/, 'Имя должно содержать только кириллические буквы'),
-  birthDate: yup
-    .string()
-    .required('Дата рождения обязательна')
-    .test('valid-date', 'Неверная дата рождения', value => {
-      if (!value) return false;
-      const date = new Date(value);
-      return !isNaN(date.getTime());
-    })
-    .test('age', 'Вам должно быть больше 12 лет', value => {
-      if (!value) return false;
-      const birthDate = new Date(value);
-      const today = new Date();
-      const age = today.getFullYear() - birthDate.getFullYear();
-      return age >= 12;
-    }),
-  city: yup.string().required('Город обязателен').oneOf(russianCities, 'Выберите город из списка'),
-  about: yup.string().max(500, 'Описание должно содержать максимум 500 символов'),
-});
-
 const passwordSchema = yup
   .string()
   .required('Пароль обязателен')
@@ -74,6 +48,35 @@ export function ProfileForm() {
   const dateInputRef = useRef<HTMLInputElement>(null);
   const dispatch = useDispatch();
   const user = useSelector(userSliceSelectors.selectUser);
+  const citiesFromStore = useSelector(getCitiesSelector);
+  const cityNames = citiesFromStore.map(c => c.name);
+
+  const profileSchema = yup.object().shape({
+    name: yup
+      .string()
+      .required('Имя обязательно')
+      .min(2, 'Имя должно содержать минимум 2 символа')
+      .max(30, 'Имя должно содержать максимум 30 символов')
+      .matches(/^[а-яА-ЯёЁ\s-]+$/, 'Имя должно содержать только кириллические буквы'),
+    birthDate: yup
+      .string()
+      .required('Дата рождения обязательна')
+      .test('valid-date', 'Неверная дата рождения', value => {
+        if (!value) return false;
+        const date = new Date(value);
+        return !isNaN(date.getTime());
+      })
+      .test('age', 'Вам должно быть больше 12 лет', value => {
+        if (!value) return false;
+        const birthDate = new Date(value);
+        const today = new Date();
+        const age = today.getFullYear() - birthDate.getFullYear();
+        return age >= 12;
+      }),
+    city: yup.string().required('Город обязателен').oneOf(cityNames, 'Выберите город из списка'),
+    about: yup.string().max(500, 'Описание должно содержать максимум 500 символов'),
+  });
+
   const registrationData = JSON.parse(localStorage.getItem('registrationData') || '{}');
 
   const [formData, setFormData] = useState({
@@ -368,7 +371,7 @@ export function ProfileForm() {
                 onChange={handleChange}
                 style={{ width: '100%' }}
               >
-                {russianCities.map(city => (
+                {cityNames.map(city => (
                   <option key={city} value={city}>
                     {city}
                   </option>

--- a/frontend/src/pages/registerStepTwo/registerStepTwo.tsx
+++ b/frontend/src/pages/registerStepTwo/registerStepTwo.tsx
@@ -1,32 +1,34 @@
-import { FC, useState } from 'react';
-import styles from './registerStepTwo.module.css';
-import { TextInput } from '@/shared/ui/textInput/textInput';
-import { CustomDatePicker } from '@/widgets/datePicker/datePicker';
-import calendarIcon from '@/app/assets/static/images/icons/calendar.svg';
-import plusIcon from '@/app/assets/static/images/icons/add.svg';
-import { CustomSelect } from '@/shared/ui/customSelect/customSelect';
-import { Autocomplete } from '@/shared/ui/autoComplete/autoComplete';
-import { MultiSelect } from '@/shared/ui/multiSelect/multiSelect';
-import { Controller, useForm } from 'react-hook-form';
-import { Button } from '@/shared/ui/button/button';
-import { yupResolver } from '@hookform/resolvers/yup';
-import * as yup from 'yup';
-import { russianCities } from '@/shared/lib/cities';
 import userIcon from '@/app/assets/static/images/background/user-info.svg';
+import plusIcon from '@/app/assets/static/images/icons/add.svg';
+import calendarIcon from '@/app/assets/static/images/icons/calendar.svg';
+import { getCategoriesSelector } from '@/services/slices/categorySlice';
+import { getCitiesSelector } from '@/services/slices/citiesSlice';
 import {
   resetStepTwoData,
   TStepTwoData,
   updateStepTwoData,
 } from '@/services/slices/registrationSlice';
-import { useDispatch, useSelector } from '@/services/store/store';
-import { RegistrationInfoPanel } from '@/shared/ui/registrationInfoPanel/registrationInfoPanel';
 import { stepActions } from '@/services/slices/stepSlice';
-import { getCategoriesSelector } from '@/services/slices/categorySlice';
+import { useDispatch, useSelector } from '@/services/store/store';
+import { Autocomplete } from '@/shared/ui/autoComplete/autoComplete';
+import { Button } from '@/shared/ui/button/button';
+import { CustomSelect } from '@/shared/ui/customSelect/customSelect';
+import { MultiSelect } from '@/shared/ui/multiSelect/multiSelect';
+import { RegistrationInfoPanel } from '@/shared/ui/registrationInfoPanel/registrationInfoPanel';
+import { TextInput } from '@/shared/ui/textInput/textInput';
+import { CustomDatePicker } from '@/widgets/datePicker/datePicker';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { FC, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import * as yup from 'yup';
+import styles from './registerStepTwo.module.css';
 
 export const RegisterStepTwo: FC = () => {
   const [isDatePickerOpen, setDatePicker] = useState(false);
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(undefined);
   const dispatch = useDispatch();
+  const citiesFromStore = useSelector(getCitiesSelector);
+  const cityNames = citiesFromStore.map(c => c.name);
   const defaultValues = useSelector(state => state.register.stepTwoData);
   const genders = ['Мужской', 'Женский'] as const;
   const schema = yup.object({
@@ -64,10 +66,7 @@ export const RegisterStepTwo: FC = () => {
         }
         return age >= 12 && age <= 100;
       }),
-    city: yup
-      .string()
-      .required('Укажите город')
-      .oneOf(russianCities, 'Выбранный город не существует'),
+    city: yup.string().required('Укажите город').oneOf(cityNames, 'Выбранный город не существует'),
     gender: yup.string().required('Укажите пол').oneOf(genders, 'Выберите пол'),
     categories: yup
       .array()
@@ -261,7 +260,7 @@ export const RegisterStepTwo: FC = () => {
               id="city"
               title="Город"
               placeholder="Не указан"
-              suggestions={russianCities}
+              suggestions={cityNames}
               error={errors.city?.message || ''}
               onFocus={() => clearErrors('city')}
             />

--- a/frontend/src/services/selectors/__tests__/catalogSelectors.test.ts
+++ b/frontend/src/services/selectors/__tests__/catalogSelectors.test.ts
@@ -89,6 +89,11 @@ describe('catalogSelectors', () => {
       loading: false,
       error: undefined,
     },
+    cities: {
+      cities: [],
+      loading: false,
+      error: undefined,
+    },
   };
 
   test('selectCatalogItems возвращает массив пользователей', () => {

--- a/frontend/src/services/selectors/__tests__/exchangeSelectors.test.ts
+++ b/frontend/src/services/selectors/__tests__/exchangeSelectors.test.ts
@@ -103,6 +103,11 @@ const mockState: RootState = {
     loading: false,
     error: undefined,
   },
+  cities: {
+      cities: [],
+      loading: false,
+      error: undefined,
+    },
 };
 
 describe('exchangeSelectors', () => {

--- a/frontend/src/services/selectors/__tests__/likeSelectors.test.ts
+++ b/frontend/src/services/selectors/__tests__/likeSelectors.test.ts
@@ -45,6 +45,11 @@ const mockState: RootState = {
     loading: false,
     error: undefined,
   },
+  cities: {
+    cities: [],
+    loading: false,
+    error: undefined,
+  },
 };
 
 describe('likeSelectors', () => {

--- a/frontend/src/services/slices/citiesSlice.ts
+++ b/frontend/src/services/slices/citiesSlice.ts
@@ -1,0 +1,42 @@
+import { getCitiesApi } from '@/api/skillSwapApi';
+import { TCity } from '@/api/types/cities';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+
+type CitiesState = {
+  cities: TCity[];
+  loading: boolean;
+  error: string | undefined;
+};
+
+const initialState: CitiesState = {
+  cities: [],
+  loading: false,
+  error: undefined,
+};
+
+export const getCities = createAsyncThunk<TCity[]>('cities', async () => getCitiesApi());
+
+const citiesSlice = createSlice({
+  name: 'cities',
+  initialState,
+  reducers: {},
+  selectors: { getCitiesSelector: state => state.cities },
+  extraReducers: builder => {
+    builder
+      .addCase(getCities.pending, state => {
+        state.loading = true;
+        state.error = undefined;
+      })
+      .addCase(getCities.rejected, state => {
+        state.loading = false;
+        state.error = 'Не удалось загрузить данные о городах';
+      })
+      .addCase(getCities.fulfilled, (state, action) => {
+        state.cities = action.payload;
+        state.loading = false;
+      });
+  },
+});
+
+export const { getCitiesSelector } = citiesSlice.selectors;
+export const citiesReducer = citiesSlice.reducer;

--- a/frontend/src/services/slices/registrationSlice.ts
+++ b/frontend/src/services/slices/registrationSlice.ts
@@ -1,7 +1,5 @@
 import { SkillCategory, SkillSubcategory } from '@/entities/skill/model/types';
-import { russianCities } from '@/shared/lib/cities';
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
-type City = (typeof russianCities)[number];
 
 export type TFullRegistrationData = TStepOneData & TStepTwoData & TStepThreeData;
 
@@ -15,7 +13,7 @@ export type TStepTwoData = {
   name: string | undefined;
   birthdate: string | undefined;
   gender: 'Мужской' | 'Женский' | undefined;
-  city: City | undefined;
+  city: string | undefined;
   categories: SkillCategory[] | undefined;
   subcategories: SkillSubcategory<SkillCategory>[] | undefined;
 };

--- a/frontend/src/services/store/store.ts
+++ b/frontend/src/services/store/store.ts
@@ -1,21 +1,19 @@
+import { catalogReducer } from '@/services/slices/catalogSlice';
+import { exchangeReducer } from '@/services/slices/exchangeSlice';
+import filtersReducer from '@/services/slices/filtersSlice';
+import likeReducer from '@/services/slices/likeSlice';
+import { registrationReducer } from '@/services/slices/registrationSlice';
+import stepsSlice from '@/services/slices/stepSlice';
 import { combineSlices, configureStore } from '@reduxjs/toolkit';
 import {
   TypedUseSelectorHook,
   useDispatch as dispatchHook,
   useSelector as selectorHook,
 } from 'react-redux';
-
-import { registrationReducer } from '@/services/slices/registrationSlice';
-import { catalogReducer } from '@/services/slices/catalogSlice';
-import { exchangeReducer } from '@/services/slices/exchangeSlice';
-import { skillsReducer } from '../slices/skillsSlice';
-
-import stepsSlice from '@/services/slices/stepSlice';
-import filtersReducer from '@/services/slices/filtersSlice';
-import likeReducer from '@/services/slices/likeSlice';
-
 import authSlice from '../slices/authSlice';
 import { categoriesReducer } from '../slices/categorySlice';
+import { citiesReducer } from '../slices/citiesSlice';
+import { skillsReducer } from '../slices/skillsSlice';
 
 export const rootReducer = combineSlices({
   register: registrationReducer,
@@ -27,6 +25,7 @@ export const rootReducer = combineSlices({
   likes: likeReducer,
   [authSlice.name]: authSlice.reducer,
   categories: categoriesReducer,
+  cities: citiesReducer,
 });
 
 const store = configureStore({

--- a/frontend/src/shared/hooks/__tests__/filters.test.ts
+++ b/frontend/src/shared/hooks/__tests__/filters.test.ts
@@ -118,6 +118,7 @@ const mockState = (filters: Partial<RootState['filters']>, searchQuery = ''): Ro
   likes: {} as RootState['likes'],
   authUser: {} as RootState['authUser'],
   categories: {} as RootState['categories'],
+  cities: {} as RootState['cities'],
 });
 
 describe('Фильтрация карточек навыков', () => {

--- a/frontend/src/widgets/filters-panel/FiltersPanel.stories.tsx
+++ b/frontend/src/widgets/filters-panel/FiltersPanel.stories.tsx
@@ -1,8 +1,8 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { FiltersPanel } from './filtersPanel';
-import { Provider } from 'react-redux';
-import { configureStore } from '@reduxjs/toolkit';
 import filtersSlice from '@/services/slices/filtersSlice';
+import { configureStore } from '@reduxjs/toolkit';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Provider } from 'react-redux';
+import { FiltersPanel } from './filtersPanel';
 
 // Используем типы из вашего слайса
 type FiltersState = {
@@ -13,7 +13,6 @@ type FiltersState = {
 };
 
 type SkillsCategories = Record<string, readonly string[]>;
-type City = Record<string, readonly string[]>;
 
 const createMockStore = (preloadedState?: Partial<FiltersState>) => {
   return configureStore({
@@ -65,10 +64,7 @@ const baseSkills: SkillsCategories = {
   Дизайн: ['UI/UX', 'Графический дизайн'],
 };
 
-const baseCities: City = {
-  Москва: [],
-  'Санкт-Петербург': [],
-};
+const baseCities: string[] = ['Москва', 'Санкт-Петербург'];
 
 export const Default: Story = {
   args: {

--- a/frontend/src/widgets/filters-panel/filtersPanel.test.tsx
+++ b/frontend/src/widgets/filters-panel/filtersPanel.test.tsx
@@ -21,10 +21,7 @@ describe('FiltersPanel', () => {
     'Иностранные языки': ['Английский'] as readonly string[],
   };
 
-  const mockCities = {
-    Москва: ['Москва'] as readonly string[],
-    'Санкт-Петербург': ['Санкт-Петербург'] as readonly string[],
-  };
+  const mockCities = ['Москва', 'Санкт-Петербург'];
 
   const createStore = (initialFilters?: Partial<FiltersState>) => {
     return configureStore({
@@ -240,7 +237,7 @@ describe('FiltersPanel', () => {
   test('Должен работать с пустыми списками городов и навыков', () => {
     const store = createStore();
     const emptySkills = {};
-    const emptyCities = {};
+    const emptyCities: [] = [];
     render(
       <Provider store={store}>
         <FiltersPanel skillsCategories={emptySkills} cities={emptyCities} />

--- a/frontend/src/widgets/filters-panel/filtersPanel.tsx
+++ b/frontend/src/widgets/filters-panel/filtersPanel.tsx
@@ -1,23 +1,23 @@
-import { useMemo, useState } from 'react';
-import { RadioGroupSection } from '@/shared/ui/radioGroupSection/radioGroupSection';
-import { CheckboxDropdownSection } from '@/shared/ui//checkboxDropdownSection/checkboxDropdownSection';
-import { experienceOptions, genderOptions } from './constants';
-import { SkillsCategories, City } from './types';
-import styles from './filtersPanel.module.css';
-import { useDispatch, useSelector } from 'react-redux';
-import { RootState } from '@/services/store/store';
-import {
-  setMode,
-  setGender,
-  setCities,
-  setSkills,
-  resetFilters,
-} from '@/services/slices/filtersSlice';
 import { setSearchQuery } from '@/services/slices/catalogSlice';
+import {
+  resetFilters,
+  setCities,
+  setGender,
+  setMode,
+  setSkills,
+} from '@/services/slices/filtersSlice';
+import { RootState } from '@/services/store/store';
+import { CheckboxDropdownSection } from '@/shared/ui//checkboxDropdownSection/checkboxDropdownSection';
+import { RadioGroupSection } from '@/shared/ui/radioGroupSection/radioGroupSection';
+import { useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { experienceOptions, genderOptions } from './constants';
+import styles from './filtersPanel.module.css';
+import { SkillsCategories } from './types';
 
 interface FiltersPanelProps {
   skillsCategories: SkillsCategories;
-  cities: City;
+  cities: string[];
 }
 
 export const FiltersPanel = ({ skillsCategories, cities }: FiltersPanelProps) => {


### PR DESCRIPTION
- Added `getCitiesApi` to `skillSwapApi` to fetch city data from the backend.
- Created `citiesSlice` to manage city state in Redux.
- Updated `App.tsx` to dispatch `getCities` on initial load.
- Replaced the static cities list with state-driven data in `CatalogPage`.
- Organized imports across modified files for consistency.

Делаю merge в dev-smilix123-6 потому-что там устранены ошибки из-за которых не поднимались контейнеры в докере.